### PR TITLE
Remove part that no longer seems active.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ The extensions are developed using the same [development process and schedule](h
 ## Providing Feedback
 
 You can use this repository to:
-- [Talk to us directly!](https://outlook.office365.com/owa/calendar/VSCodeRemote@microsoft.onmicrosoft.com/bookings/s/qX09ky0ICEuBGFOByCJEqA2) Use this link to book time with a member of the product team to tell us more about your remote setup and experience so far.  
 - [Up-vote a feature or request a new one](https://aka.ms/vscode-remote/feature-requests).
 - Search for [existing issues](https://aka.ms/vscode-remote/issues) already reported for potential workarounds.
 - [Report a problem](https://aka.ms/vscode-remote/issues/new) if you don't find what you are looking for.


### PR DESCRIPTION
Is the "Talk to us directly" referenced on the readme still active? On the readme is says "Talk to us directly! Use this link to book time with a member of the product team to tell us more about your remote setup and experience so far." I did that but when I tried to log into the call the conference ID wasn't found. I also noticed that the person it said I was going to be talking with is no longer at Microsoft. If it is active and it just didn't work on this time then feel free to close this PR.