### PR TITLE
Update action to search for info-needed

### DIFF
--- a/.github/workflows/info-needed-closer.yml
+++ b/.github/workflows/info-needed-closer.yml
@@ -1,4 +1,4 @@
-name: Needs More Info Closer
+name: Info-Needed Closer
 on:
   schedule:
     - cron: 20 12 * * * # 5:20am Redmond
@@ -18,11 +18,11 @@ jobs:
           ref: stable
       - name: Install Actions
         run: npm install --production --prefix ./actions
-      - name: Run Needs More Info Closer
+      - name: Run info-needed Closer
         uses: ./actions/needs-more-info-closer
         with:
           appInsightsKey: ${{secrets.TRIAGE_ACTIONS_APP_INSIGHTS}}
-          label: needs more info
+          label: info-needed
           closeDays: 7
           additionalTeam:	"cleidigh|usernamehw|gjsjohnmurray|IllusionMH"
           closeComment: "This issue has been closed automatically because it needs more information and has not had recent activity. See also our [issue reporting](https://aka.ms/vscodeissuereporting) guidelines.\n\nHappy Coding!"


### PR DESCRIPTION
Currently we search for `needs more info` which has been replaced with `info-needed` to normalize our labels. This updates the action to act appropriately.