### PR TITLE
Init baseline configurations

### DIFF
--- a/ssh/README.md
+++ b/ssh/README.md
@@ -1,0 +1,15 @@
+# Remote - SSH
+
+## Baseline Tests
+
+The collection of [dev container](https://containers.dev) configurations in this directory are used during the development and release of the Remote - SSH extension.  This collection will grow along with development of the product, user bug reports, and product goals to generate a set of actionable regression tests.  Internally, a unit testing suite directly employs these configurations and the associated `baseline.json`.
+
+### Testing yourself
+
+To test these configurations yourself against a built of the Remote - SSH extension, perform the following steps. 
+
+1. Install the devcontainer CLI (`npm install -g @devcontainers/cli`). This requires docker on your local machine.
+1. Select a configuration and bring the target environment up (`devcontainer up --workspace-folder <PATH_TO_CONFIG>`)
+1. These configurations will start an SSH server on a predetermined port addressable on localhost.
+1. (Optional) Reconfigure your extension settings to match a scenario within the `baseline.json`.
+1. Using the Remote - SSH extension, connect to the container (eg: ssh root@localhost:5678).  The default password is `foobar`.

--- a/ssh/baseline-configs/fedora+/.devcontainer.json
+++ b/ssh/baseline-configs/fedora+/.devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"dockerFile": "Dockerfile",
+	"appPort": 5670,
+	"overrideCommand": false
+}

--- a/ssh/baseline-configs/fedora+/Dockerfile
+++ b/ssh/baseline-configs/fedora+/Dockerfile
@@ -1,0 +1,13 @@
+FROM fedora:latest
+
+RUN dnf install -y openssh-server wget
+
+RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -i 's/#AllowTcpForwarding yes/AllowTcpForwarding yes/' /etc/ssh/sshd_config
+
+RUN ssh-keygen -A
+
+RUN echo "root:foobar" | chpasswd
+
+EXPOSE 5670
+CMD ["/usr/sbin/sshd", "-D", "-p", "5670"]

--- a/ssh/baseline-configs/fedora/.devcontainer.json
+++ b/ssh/baseline-configs/fedora/.devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"dockerFile": "Dockerfile",
+	"appPort": 5671,
+	"overrideCommand": false
+}

--- a/ssh/baseline-configs/fedora/Dockerfile
+++ b/ssh/baseline-configs/fedora/Dockerfile
@@ -1,0 +1,15 @@
+FROM fedora:latest
+
+RUN dnf install -y openssh-server
+
+RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -i 's/#AllowTcpForwarding yes/AllowTcpForwarding yes/' /etc/ssh/sshd_config
+
+RUN ssh-keygen -A
+
+RUN echo "root:foobar" | chpasswd
+
+# TODO: expose only on an isolated docker network to avoid conflicts?
+#       Think about how extension would communicate
+EXPOSE 5671
+CMD ["/usr/sbin/sshd", "-D", "-p", "5671"]

--- a/ssh/baseline.json
+++ b/ssh/baseline.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "./baseline.schema.json",
+    "baselines": [
+        {
+            "id": "fedora_tools_execServer",
+            "displayName": "Fedora latest with common tools",
+            "description": "The latest Fedora image with common tools installed (wget)",
+            "config": "fedora+",
+            "overrideSettings": {
+                "useExecServer": true
+            },
+            "expectSuccess": true,
+            "sshPort": 5670,
+            "validators": []
+        },
+        {
+            "id": "fedora_tools_noExecServer",
+            "displayName": "Fedora latest with common tools",
+            "description": "The latest Fedora image with common tools installed (wget)",
+            "config": "fedora+",
+            "overrideSettings": {
+                "useExecServer": false
+            },
+            "expectSuccess": true,
+            "sshPort": 5670,
+            "validators": []
+        }
+    ]
+}


### PR DESCRIPTION
closes https://github.com/microsoft/vscode-remote-release/issues/10248

This seeds the initiative aimed at collecting a set of configurations to represent Remote - SSH compatibility against a wide variety of inputs, distros, etc.

Tooling has been built internally, based on the dev container CLI, to exercise the extension against this (growing) list of configurations.

Stay tuned into the following iteration plans for more progress on this initiative.